### PR TITLE
Do not attempt to scan non-SHF_ALLOC sections for ELF files and non-IMAGE_SCN_MEM_READ sections for PE files

### DIFF
--- a/patternsleuth/src/lib.rs
+++ b/patternsleuth/src/lib.rs
@@ -421,6 +421,7 @@ impl<'data> Memory<'data> {
         Ok(Self {
             sections: sections
                 .into_iter()
+                .filter(|(s, _)| Self::is_section_scannable(s.flags()))
                 .map(|(s, d)| {
                     Ok(NamedMemorySection::new(
                         s.name()?.to_string(),
@@ -438,6 +439,7 @@ impl<'data> Memory<'data> {
         Ok(Self {
             sections: sections
                 .into_iter()
+                .filter(|(s, _)| Self::is_section_scannable(s.flags()))
                 .map(|(s, d)| {
                     Ok(NamedMemorySection::new(
                         s.name()?.to_string(),


### PR DESCRIPTION
Fixes #12