### PR TITLE
feat: three-state BuildConfiguration (shipping/test/development) from the non-shipping and stats strings

### DIFF
--- a/patternsleuth/src/resolvers/unreal/engine_version.rs
+++ b/patternsleuth/src/resolvers/unreal/engine_version.rs
@@ -227,7 +227,9 @@ impl_resolver!(PEImage, EngineVersionStrings, |ctx| async {
     bail_out!("not found");
 });
 
-/// Detects the build configuration (DebugGame/Development vs Shipping)
+/// Build configuration, from two strings that track the preprocessor conditions changing object layout.
+/// A non-shipping string (!UE_BUILD_SHIPPING) and a stats string (STATS).
+/// Shipping: neither. Test: non-shipping only. Development: both (also Debug/DebugGame).
 #[derive(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde-resolvers",
@@ -235,7 +237,8 @@ impl_resolver!(PEImage, EngineVersionStrings, |ctx| async {
 )]
 pub enum BuildConfiguration {
     Shipping,
-    Development, // Includes DebugGame, Test, Dev, Development
+    Test,
+    Development,
 }
 impl FromStr for BuildConfiguration {
     type Err = ResolveError;
@@ -247,19 +250,23 @@ impl FromStr for BuildConfiguration {
 impl_resolver!(all, BuildConfiguration, |ctx| async {
     use crate::resolvers::unreal::util;
 
-    // This debug string only appears in non-shipping builds
-    let debug_string =
+    // Emitted by HandleListParticleSystemsCommand, which is compiled under #if !UE_BUILD_SHIPPING.
+    // Its presence mirrors TBucketMap's !UE_BUILD_SHIPPING ReadOnlyLock field.
+    let non_shipping_string =
         "Size,Name,PSysSize,ModuleSize,ComponentSize,ComponentCount,CompResSize,CompTrueResSize\0";
+    // Emitted by the stat command help, compiled under #if STATS. Its presence mirrors the
+    // STATS-gated StatId member in FUObjectItem and (pre 4.25) UObjectBase.
+    let stats_string = "Here is the brief list of stats console commands\0";
 
-    let pattern = util::utf16_pattern(debug_string);
-    let results = ctx.scan(pattern).await;
+    let non_shipping = ctx.scan(util::utf16_pattern(non_shipping_string)).await;
+    let stats = ctx.scan(util::utf16_pattern(stats_string)).await;
 
-    if !results.is_empty() {
-        // Found the debug string - this is a development build
-        Ok(BuildConfiguration::Development)
-    } else {
-        // No debug string found - assume shipping build
+    if non_shipping.is_empty() {
         Ok(BuildConfiguration::Shipping)
+    } else if stats.is_empty() {
+        Ok(BuildConfiguration::Test)
+    } else {
+        Ok(BuildConfiguration::Development)
     }
 });
 


### PR DESCRIPTION
## Detect Test builds separately from Development

`BuildConfiguration` only returned `Shipping` or `Development`, and `Development` also covered Test. That's not enough if you use it to pick struct layouts, because the two common non-shipping layout changes have different guards:

- `#if !UE_BUILD_SHIPPING` (Development and Test): the `ReadOnlyLock` field on `TBucketMap` in 5.0+, which shifts the `FUObjectHashTables` members.
- `#if STATS` (Development only, off in Test by default): `FUObjectItem::StatId` and the pre-4.25 `UObjectBase` `TStatId`.

So treating Test as Development applies the STATS-only shifts to a build that doesn't have them. Downstream this crashed on a 5.6.1 Test build.

### Change

`BuildConfiguration` is now `{ Shipping, Test, Development }`. It looks for two strings: `"Size,Name,PSysSize,..."` (`HandleListParticleSystemsCommand`, `#if !UE_BUILD_SHIPPING`) and `"Here is the brief list of stats console commands"` (stat help, `#if STATS`). Neither means Shipping, the first alone means Test, both means Development. Checking the actual STATS string also covers a Test build that forces stats on. Both strings are present and correctly guarded from 4.10 to 5.7.

### Testing

Shipping: Deep Rock Galactic (4.27), Palworld (5.1). Test: VEIN (5.6.1). Development: any Development cook. Or grep the exe for the two strings.