### PR TITLE
patternsleuth: Add FName constructor prologue variant for UE 5.8 / recent MSVC

### DIFF
--- a/patternsleuth/src/resolvers/unreal/fname.rs
+++ b/patternsleuth/src/resolvers/unreal/fname.rs
@@ -124,8 +124,12 @@ impl_resolver_singleton!(PEImage, FNameCtorWchar, |ctx| async {
     // FName(wchar_t const*, EFindName) prologue
     let ctor = async {
         join_all([
+            // Standard UE4/UE5 MSVC: mov [rsp+8], rbx; push rdi; sub rsp, 30h; mov rbx, rcx; mov edi, r8d ...
             "48 89 5C 24 08 57 48 83 EC 30 48 8B D9 41 8B F8 33 C9 4C 8B DA 44 8B D1 4C 8B CA 48 85 D2 74 ?? 0F B7 02 66 85 C0",
+            // UE5 MSVC variant 1: mov [rsp+8], rbx; push rdi; sub rsp, 30h; mov rbx, rcx; mov [rsp+20h], rdx ...
             "48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 89 54 24 20 33 C9 41 8B F8 4C 8B D2 44 8B C9 48 85 D2 74 ?? 0F B7 02 66 85 C0",
+            // UE 5.8+ MSVC variant 2: push rbx; sub rsp, 30h; mov rbx, rcx; mov [rsp+20h], rdx; xor ecx, ecx; mov r9, rdx; mov r8d, ecx ...
+            "40 53 48 83 EC 30 48 8B D9 48 89 54 24 20 33 C9 4C 8B CA 44 8B C1 48 85 D2 74 ?? 0F B7 02 66 85 C0",
         ].map(|p| ctx.scan(Pattern::new(p).unwrap())))
         .await
         .into_iter()


### PR DESCRIPTION
### Summary
Adds a 3rd compiler emission prologue variant for `FName::FName(wchar_t const*, EFindName)` (`FNameCtorWchar`) on PE images.

### Context & Root Cause
In recent MSVC compiler updates (observed in Unreal Engine 5.8 shipping builds, e.g. *Far Far West* Steam buildid `24978658`), the compiler changed register preservation and parameter staging in the function prologue:
- **Prior MSVC variant**: Saved `rbx` via `mov [rsp+8], rbx`, preserved `rdi` via `push rdi`, and loaded `EFindName` into `edi`:
  `48 89 5C 24 08 57 48 83 EC 30 48 8B D9 48 89 54 24 20 33 C9 41 8B F8 4C 8B D2 44 8B C9 48 85 D2 ...`
- **New MSVC variant**: Preserves `rbx` via `push rbx` (`40 53`), omits `push rdi`, and adjusts scratch registers:
  `40 53 48 83 EC 30 48 8B D9 48 89 54 24 20 33 C9 4C 8B CA 44 8B C1 48 85 D2 74 ?? 0F B7 02 66 85 C0`

```x86asm
push  rbx                 ; 40 53
sub   rsp, 0x30           ; 48 83 EC 30
mov   rbx, rcx            ; 48 8B D9 (this = InName)
mov   [rsp+0x20], rdx     ; 48 89 54 24 20
xor   ecx, ecx            ; 33 C9
mov   r9, rdx             ; 4C 8B CA
mov   r8d, ecx            ; 44 8B C1
test  rdx, rdx            ; 48 85 D2 (null check)
je    short +??           ; 74 ??
movzx eax, word ptr [rdx] ; 0F B7 02 (read first wchar)
test  ax, ax              ; 66 85 C0 (empty check)
```

Without this variant, PE binaries using this compiler profile fail direct prologue resolution and must fall back to per-game signature overrides.

### Verification
- Tested with *Far Far West* (UE 5.8, Steam buildid `24978658`): Resolves entry point with a unique 1-of-1 match.
- Second-pass verification in UE4SS confirmed valid FName construction (`FName("ByteProperty", FNAME_Find)`).
- Unit tests pass cleanly (`cargo test --lib -p patternsleuth --features image-pe,image-elf`).
